### PR TITLE
Add links to Wirecloud and Keyrock APIs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 ![FIWARE Banner](https://fiware.github.io/specifications/img/fiware.png)
 
-# Open API Specifications 
+# Open API Specifications
 
 This repository contains the [Open API](https://www.openapis.org/) / [Swagger](https://swagger.io/) specifications for the following FIWARE Generic Enablers:
 
 * [NGSI v2 API](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/ngsiv2/ngsiv2-openapi.json)
 * [IoT Agent library](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/iot.IoTagent-node-lib/IoTagent-node-lib-openapi.json)
+* [Wirecloud API](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/apps.Wirecloud/Wirecloud-openapi.json)
+* [Keyrock API](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/security.Idm/Idm-openapi.json)
 
 The `OpenAPI` folder contains the raw Open API specification JSON files.
 


### PR DESCRIPTION
This allows direct Swagger viewer access to the relevant Swagger files